### PR TITLE
Flex sensor API for MSP432

### DIFF
--- a/device/build_switches.h
+++ b/device/build_switches.h
@@ -41,14 +41,14 @@
 #define ENABLE_UNIT_TEST_ADC_MSP432     (0 & ENABLE_UNIT_TEST)   // Issue #36: Enables unit test for reading ADC values from flex amplifier.
 #define ENABLE_UNIT_TEST_FLEX_SENSORS   (0 & ENABLE_UNIT_TEST)   // Issue #7: Enables unit test for reading all 10 flex sensor voltage levels.
 #define ENABLE_UNIT_TEST_HC05_DEVICE_NAME (0 & ENABLE_UNIT_TEST)   // Issue #37: Enable test to read back HC-05 "NAME" register (returns "HC-05" by default)
-#define ENABLE_UNIT_TEST_HC05_RW_TO_SLAVE (1 & ENABLE_UNIT_TEST) // Issue #35: Enable unit test to repeatedly write to / read from slave HC-05.
+#define ENABLE_UNIT_TEST_HC05_RW_TO_SLAVE (0 & ENABLE_UNIT_TEST) // Issue #35: Enable unit test to repeatedly write to / read from slave HC-05.
 #define ENABLE_UNIT_TEST_I2C            (0 & ENABLE_UNIT_TEST)   // Issue #39: Enable basic I2C write/read test to be read on logic analyzer.
 #define ENABLE_UNIT_TEST_EXT_PWR_SWITCH (0 & ENABLE_UNIT_TEST)  // Issue #45: Enable test that toggles external power switch. Power output be manually validated with DAD board.
 #define ENABLE_UNIT_TEST_MPU6500_WHOAMI_SPI (0 & ENABLE_UNIT_TEST) // Issue #47: Enable SPI read from MPU6500's WHO_AM_I register.
 #define ENABLE_UNIT_TEST_MPU6050_WHOAMI_I2C (0 & ENABLE_UNIT_TEST) // Issue #47: Enable I2C read from MPU6050's WHO_AM_I register.
 #define ENABLE_UNIT_TEST_MPU6050_SENSORDATA (0 & ENABLE_UNIT_TEST) // Issue #47: Enable reading gyro/accelerometer data from MPU6050 and converting to Euler angles using DMP.
 #define ENABLE_UNIT_TEST_MPU6050_SENSORDATA_RAW (0 & ENABLE_UNIT_TEST) // Issue #47: Reading raw gyro / accelerometer sensor data from MPU6050 without DMP.
-#define ENABLE_UNIT_TEST_LCD_DEMO       (0 & ENABLE_UNIT_TEST)  // Issue #46: Enable demo animations to run on CFAL6448A lcd over SPI.
+#define ENABLE_UNIT_TEST_LCD_DEMO       (1 & ENABLE_UNIT_TEST)  // Issue #46: Enable demo animations to run on CFAL6448A lcd over SPI.
 #define ENABLE_UNIT_TEST_LCD_TEXT       (0 & ENABLE_UNIT_TEST)  // Issue #46: Draws custom text and image to the LCD.
 
 #define ENABLE_HC05_CONFIG_MSTR (0) // Issue #35: Script to configure the master HC-05's role, slave address, etc.

--- a/device/inc/adc_if.h
+++ b/device/inc/adc_if.h
@@ -42,6 +42,11 @@
 #define ADC_B               (1)   ///< Adc module B
 #define ADC_MAX_NUM_CHAN    (2)   ///< Number of ADC channels used
 
+// MSP432 channel
+#define ADC_CH0             (0)
+#define ADC_CH1             (1)
+#define ADC_CH2             (2)
+
 /*
 * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
 * STRUCTS
@@ -74,7 +79,7 @@ namespace Adc {
 #if TARGET_HW_MSP432
     namespace MSP432 {
         bool Init               ();
-        uint16_t ReadAdcChannel ();
+        uint16_t ReadAdcChannel (uint8_t adc_channel);
     }
 #endif // TARGET_HW_MSP432
 

--- a/device/inc/flex_sensors_api.h
+++ b/device/inc/flex_sensors_api.h
@@ -7,53 +7,24 @@
 * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
 */
 
+#include "target_hw_common.h"
 #include <adc_if.h>
 #include <mux_if.h>
-#include <stdio.h>
 
 #define ADC_CHAN_MCP    (0) // ADC channel used to read MCP joint data
 #define ADC_CHAN_PIP    (1) // ADC channel used to read PIP joint data
 
+#define ADC_CHAN_FLEX_SENSORS   ADC_CH0 // ADC channel being used to read flex sensor values
+
+#define FLEX_MAX_NUM_FINGERS    3
+
+/*
+* +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
+* STRUCTS
+* +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
+*/
+
 namespace FlexSensors {
-
-    /*
-    * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
-    * STRUCTS
-    * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
-    */
-    
-    /*
-     * +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+ 
-     * Description: fingerJoints_t
-     * This struct contains 10-bit ADC readings for both joints of a finger.
-     * +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
-    */
-    typedef struct
-    {
-        int mcp; // First knuckle 
-        int pip; // Second knuckle
-    } fingerJoints_t;
-
-    /*
-    * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
-    * ENUMS
-    * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
-    */
-
-    /*
-     * +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+ 
-     * Description: finger_e
-     * +-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
-    */
-    typedef enum 
-    {
-        FINGER_THUMB = 0,
-        FINGER_POINTER = 1,
-        FINGER_MIDDLE = 2,
-        FINGER_RING = 3,
-        FINGER_PINKY = 4
-    } finger_e;
-
     /*
     * +=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+
     * PROTOTYPES
@@ -61,7 +32,7 @@ namespace FlexSensors {
     */
     
     bool Init();
-    bool GetJointsData(finger_e finger, fingerJoints_t* joints);
+    uint8_t GetJointsData(uint8_t finger);
 }
 
 #endif // _SRC_FLEX_SENSORS_API

--- a/device/src/adc_if.cpp
+++ b/device/src/adc_if.cpp
@@ -71,7 +71,7 @@ uint16_t Adc::ReadAdcChannel(uint8_t adc_channel) {
 #elif ENABLE_ADC_C2000
     return Adc::C2000::ReadAdcChannel(adc_channel);
 #elif TARGET_HW_MSP432
-    return Adc::MSP432::ReadAdcChannel();
+    return Adc::MSP432::ReadAdcChannel(adc_channel);
 #else
     return false;
 #endif // ENABLE_ADC_API_PYTHON
@@ -110,7 +110,7 @@ bool Adc::MSP432::Init() {
     return true;
 }
 
-uint16_t Adc::MSP432::ReadAdcChannel() {
+uint16_t Adc::MSP432::ReadAdcChannel(uint8_t adc_channel) {
 
     // Clear conversion ready flag
     flagAdcReady = false;


### PR DESCRIPTION
This PR modifies the existing flex sensors API to support the MSP432's implementation of the ADC and Mux modules.